### PR TITLE
Update Unity to 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Updated project urls
+- Updated Unity to 4.0.1
 
 ## [2.0.0] - 2017-06-20
 ### Changed

--- a/Unity.Wcf/Unity.Wcf.csproj
+++ b/Unity.Wcf/Unity.Wcf.csproj
@@ -40,14 +40,17 @@
     <AssemblyOriginatorKeyFile>Unity.Wcf.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.Unity, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Unity.Wcf/Unity.Wcf.nuspec
+++ b/Unity.Wcf/Unity.Wcf.nuspec
@@ -10,13 +10,13 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Unity.Wcf is a library that allows simple Integration of Microsoft's Unity IoC container with WCF. This project includes a bespoke InstanceProvider that creates a child container per client connection and disposes of all registered IDisposable instances once the connection is terminated.</description>
     <tags>wcf unity ioc di</tags>
-	<dependencies>
+    <dependencies>
     </dependencies>
-	<frameworkAssemblies>
-		<frameworkAssembly assemblyName="System.ServiceModel.Activation" />
-	</frameworkAssemblies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.ServiceModel.Activation" />
+    </frameworkAssemblies>
   </metadata>
-    <files>
-        <file src="content\**\*.*" target="content" />
-    </files>
+  <files>
+    <file src="content\**\*.*" target="content" />
+  </files>
 </package>

--- a/Unity.Wcf/UnityInstanceContextExtension.cs
+++ b/Unity.Wcf/UnityInstanceContextExtension.cs
@@ -22,16 +22,16 @@ namespace Unity.Wcf
         {
             if (_childContainer != null)
             {
-                _childContainer.Dispose();                
+                _childContainer.Dispose();
             }
         }
 
         public void Attach(InstanceContext owner)
-        {            
+        {
         }
 
         public void Detach(InstanceContext owner)
-        {            
-        }        
+        {
+        }
     }
 }

--- a/Unity.Wcf/UnityInstanceProvider.cs
+++ b/Unity.Wcf/UnityInstanceProvider.cs
@@ -10,7 +10,7 @@ namespace Unity.Wcf
     {
         private readonly IUnityContainer _container;
         private readonly Type _contractType;
-        
+
         public UnityInstanceProvider(IUnityContainer container, Type contractType)
         {
             if (container == null)
@@ -42,7 +42,7 @@ namespace Unity.Wcf
 
         public void ReleaseInstance(InstanceContext instanceContext, object instance)
         {
-            instanceContext.Extensions.Find<UnityInstanceContextExtension>().DisposeOfChildContainer();            
-        }        
+            instanceContext.Extensions.Find<UnityInstanceContextExtension>().DisposeOfChildContainer();
+        }
     }
 }

--- a/Unity.Wcf/UnityServiceHost.cs
+++ b/Unity.Wcf/UnityServiceHost.cs
@@ -37,7 +37,7 @@ namespace Unity.Wcf
                 foreach (var contractDescription in ImplementedContracts.Values)
                 {
                     contractDescription.Behaviors.Add(contractBehavior);
-                }                
+                }
             }
         }
 

--- a/Unity.Wcf/UnityServiceHostFactory.cs
+++ b/Unity.Wcf/UnityServiceHostFactory.cs
@@ -16,6 +16,6 @@ namespace Unity.Wcf
             ConfigureContainer(container);
 
             return new UnityServiceHost(container, serviceType, baseAddresses);
-        }        
-    }    
+        }
+    }
 }

--- a/Unity.Wcf/packages.config
+++ b/Unity.Wcf/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Unity" version="3.5.1404.0" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="Unity" version="4.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The upgrade from Unity 3.5 to Unity 4.0 is non-breaking.

In projects implementing the existing version of Unity.Wcf, Unity 3.5 must be used throughout the project because the `UnityServiceHost` constructor requires a Unity 3.5 `IUnityContainer`. Upgrading the Unity NuGet reference allows developers to use Unity 4.0.1 in their projects with Unity.Wcf.

Code files have been minorly reformatted as well to improve project quality-of-life.